### PR TITLE
Uncomment general (non-versioned) clang-tidy binary

### DIFF
--- a/carma_ament_clang_tidy/carma_ament_clang_tidy/main.py
+++ b/carma_ament_clang_tidy/carma_ament_clang_tidy/main.py
@@ -19,6 +19,8 @@
 #   - replaced ament_clang_tidy with carma_ament_clang_tidy to avoid name collisions
 #   - uncomment clang-tidy binary name from bin_names to lift
 #     restriction on specific clang-tidy version
+#   - remove clang-tidy-6.0 binary name because it can be abstracted by
+#     the clang-tidy binary
 
 import argparse
 from collections import defaultdict
@@ -102,8 +104,7 @@ def main(argv=sys.argv[1:]):
         return 1
 
     bin_names = [
-        'clang-tidy',
-        'clang-tidy-6.0',
+        'clang-tidy'
     ]
     clang_tidy_bin = find_executable(bin_names)
     if not clang_tidy_bin:

--- a/carma_ament_clang_tidy/carma_ament_clang_tidy/main.py
+++ b/carma_ament_clang_tidy/carma_ament_clang_tidy/main.py
@@ -17,6 +17,8 @@
 #
 # Changes from original Open Source Robotics Foundation, Inc. version:
 #   - replaced ament_clang_tidy with carma_ament_clang_tidy to avoid name collisions
+#   - uncomment clang-tidy binary name from bin_names to lift
+#     restriction on specific clang-tidy version
 
 import argparse
 from collections import defaultdict
@@ -100,7 +102,7 @@ def main(argv=sys.argv[1:]):
         return 1
 
     bin_names = [
-        # 'clang-tidy',
+        'clang-tidy',
         'clang-tidy-6.0',
     ]
     clang_tidy_bin = find_executable(bin_names)


### PR DESCRIPTION
# PR Details
## Description

The `clang-tidy` binary name was commented before forking from upstream. We are lifting this restriction so users can use newer clang-tidy versions.

## Related GitHub Issue

Closes #5 

## Related Jira Key

[CDAR-672](https://usdot-carma.atlassian.net/browse/CDAR-672)

## Motivation and Context

`clang-tidy-6.0` is an old version, so restricting `ament_clang_tidy` to this is overly restrictive.

## How Has This Been Tested?

Manually with downstream packages.

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-672]: https://usdot-carma.atlassian.net/browse/CDAR-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ