### PR TITLE
Replace subprocess invocation error string with clang-tidy's output

### DIFF
--- a/carma_ament_clang_tidy/carma_ament_clang_tidy/main.py
+++ b/carma_ament_clang_tidy/carma_ament_clang_tidy/main.py
@@ -21,6 +21,10 @@
 #     restriction on specific clang-tidy version
 #   - remove clang-tidy-6.0 binary name because it can be abstracted by
 #     the clang-tidy binary
+#   - replace original subprocess invocation error message with clang-tidy's
+#     command output. This allows users to see what clang-tidy flagged as
+#     Problematic. A non-zero return for clang-tidy is not an invocation
+#     error.
 
 import argparse
 from collections import defaultdict
@@ -168,9 +172,7 @@ def main(argv=sys.argv[1:]):
                 output += subprocess.check_output(full_cmd,
                                                   stderr=subprocess.DEVNULL).strip().decode()
             except subprocess.CalledProcessError as e:
-                print('The invocation of "%s" failed with error code %d: %s' %
-                      (os.path.basename(clang_tidy_bin), e.returncode, e),
-                      file=sys.stderr)
+                print(e.output.decode(), file=sys.stderr)
         return (files, output)
 
     files = []


### PR DESCRIPTION
# PR Details
## Description

Replace original subprocess invocation error message with clang-tidy's command output. This allows users to see what clang-tidy flagged as Problematic. A non-zero return for clang-tidy is not an invocation error.

## Related GitHub Issue

Closes #7 

## Related Jira Key

[CDAR-672](https://usdot-carma.atlassian.net/browse/CDAR-672)

## Motivation and Context

The previous output did not include clang-tidy's diagnostic messages, which is necessary for developers to fix their code.

## How Has This Been Tested?

Manually in downstream packages

## Types of changes

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.


[CDAR-672]: https://usdot-carma.atlassian.net/browse/CDAR-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ